### PR TITLE
Implement display values for list selector

### DIFF
--- a/src/red4ext/ModRuntimeSettingsVar.hpp
+++ b/src/red4ext/ModRuntimeSettingsVar.hpp
@@ -113,9 +113,19 @@ struct ModRuntimeSettingsVarEnum : public ModRuntimeSettingsVar {
 
     auto e = RED4ext::CRTTISystem::Get()->GetEnumByScriptName(prop->type->name);
     if (e) {
+      const auto displayValuesPrefix = RED4ext::FNV1a64("ModSettings.displayValues.");
+
       for (const auto &value : e->hashList) {
-          displayValues.EmplaceBack(value);
+          const auto displayValueAttr = RED4ext::FNV1a64(value.ToString(), displayValuesPrefix);
+          const auto displayValue = prop->runtimeProperties.Get(displayValueAttr);
+          if (displayValue) {
+            RED4ext::CNamePool::Add(displayValue->c_str());
+            displayValues.EmplaceBack(displayValue->c_str());
+          } else {
+            displayValues.EmplaceBack(value);
+          }
       }
+
       for (const auto &value : e->valueList) {
           values.EmplaceBack((int32_t)value);
       }

--- a/src/redscript/mod_settings/_SettingsSelectorControllers.reds
+++ b/src/redscript/mod_settings/_SettingsSelectorControllers.reds
@@ -368,7 +368,11 @@ public class ModStngsSelectorControllerListInt extends SettingsSelectorControlle
     if !value.ListHasDisplayValues() {
       inkTextRef.SetText(this.m_ValueText, IntToString(value.GetValue()));
     } else {
-      inkTextRef.SetText(this.m_ValueText, ToString(value.GetDisplayValue(index)));
+      let text = GetLocalizedTextByKey(value.GetDisplayValue(index));
+      if StrLen(text) == 0 {
+        text = ToString(value.GetDisplayValue(index));
+      };
+      inkTextRef.SetText(this.m_ValueText, text);
     };
     this.SelectDot(index);
   }


### PR DESCRIPTION
```swift
enum ModSetting {
  OptionA = 0,
  OptionB = 1,
  OptionC = 2
}

class ModSettings {
  @runtimeProperty("ModSettings.mod", "Mod")
  @runtimeProperty("ModSettings.displayName", "UI-ModSetting-Label")
  @runtimeProperty("ModSettings.displayValues.OptionA", "UI-ModSetting-OptionA")
  @runtimeProperty("ModSettings.displayValues.OptionB", "Fixed Option B")
  public let setting: ModSetting = ModSetting.OptionA;
}
```

This example will produce the following results for enum values:

| Enum Value | Display Value |
| --- | --- |
| `OptionA` | Localized text `GetLocalizedText("UI-ModSetting-OptionA")`  |
| `OptionB` | Fixed text `"Fixed Option B"`  |
| `OptionC` | Value name `"OptionC"`  |
